### PR TITLE
Fix LockedHeap::init, add test; bump version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab_allocator"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Robert Węcławski <r.weclawski@gmail.com>"]
 license = "MIT"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl LockedHeap {
         LockedHeap(Mutex::new(None))
     }
 
-    pub unsafe fn init(&mut self, heap_start_addr: usize, size: usize) {
+    pub unsafe fn init(&self, heap_start_addr: usize, size: usize) {
         *self.0.lock() = Some(Heap::new(heap_start_addr, size));
     }
 


### PR DESCRIPTION
The `init` function on LockedHeap needed to take
`&self`, not `&mut self`.  Change it accordingly
and add a test to ensure that LockedHeap does the
right thing.

Similarly, bump the version number as I'd like to
use this shortly.