### PR TITLE
Update allocator interface again, bump version number.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab_allocator"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Robert Węcławski <r.weclawski@gmail.com>"]
 license = "MIT"
 
@@ -10,5 +10,5 @@ keywords = ["slab", "allocator", "no_std", "heap", "kernel"]
 repository = "https://github.com/weclaw1/slab_allocator"
 
 [dependencies]
-linked_list_allocator = "0.6.2"
+linked_list_allocator = "0.6.3"
 spin = "0.4.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod slab;
 
 use core::ops::Deref;
 
-use alloc::allocator::{Alloc, AllocErr, Layout};
+use alloc::alloc::{Alloc, AllocErr, Layout};
 use core::alloc::GlobalAlloc;
 use core::ptr::NonNull;
 use slab::Slab;

--- a/src/slab.rs
+++ b/src/slab.rs
@@ -1,4 +1,4 @@
-use alloc::allocator::{AllocErr, Layout};
+use alloc::alloc::{AllocErr, Layout};
 use core::ptr::NonNull;
 
 pub struct Slab {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use alloc::allocator::Layout;
+use alloc::alloc::Layout;
 use core::mem::{align_of, size_of};
 
 const HEAP_SIZE: usize = 8 * 4096;


### PR DESCRIPTION
The allocator interface changed again slightly:
alloc::allocator was renamed to alloc::alloc (at least for
the symbols we import).  Update accordingly and bump
version number.