### PR TITLE
Resolve clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub const NUM_OF_SLABS: usize = 8;
 pub const MIN_SLAB_SIZE: usize = 4096;
 pub const MIN_HEAP_SIZE: usize = NUM_OF_SLABS * MIN_SLAB_SIZE;
 
+#[derive(Copy, Clone)]
 pub enum HeapAllocator {
     Slab64Bytes,
     Slab128Bytes,


### PR DESCRIPTION
This PR gets us to compile cleanly with `cargo clippy` as of Clippy 0.0.212.